### PR TITLE
Updated nginx version and streamlined install script.

### DIFF
--- a/compile
+++ b/compile
@@ -2,7 +2,7 @@
 
 BASEDIR=$(cd "$(dirname "$0")"; pwd)
 TMPDIR=tmp
-NGINXV=nginx-1.7.3
+NGINXV=nginx-1.6.0
 NGINXDIR=$NGINXV/
 
 # Create and move into the tmp dirctory


### PR DESCRIPTION
I enabled the use of a fallback from curl to wget in case curl is not installed (as by default on Ubuntu) and streamlined the install process by only displaying errors and displaying simple messages for everything else.
