### PR TITLE
Adding option to download mainline version. 

### DIFF
--- a/compile
+++ b/compile
@@ -2,7 +2,7 @@
 
 BASEDIR=$(cd "$(dirname "$0")"; pwd)
 TMPDIR=tmp
-[[ "$1" == "--latest" ]] && NGINXV=nginx-1.7.3 || NGINXV=nginx-1.6.0
+[[ "$1" == "--latest" ]] && NGINXV=nginx-1.7.4 || NGINXV=nginx-1.6.0
 echo "nginx version "$NGINXV" selected" 
 NGINXDIR=$NGINXV/
 


### PR DESCRIPTION
This change adds the option to download the latest mainline version (1.7.4) using the --latest flag. 
